### PR TITLE
Retire Oasyce chain alert delivery and deploy path

### DIFF
--- a/.github/workflows/deploy-alert-fix.yml
+++ b/.github/workflows/deploy-alert-fix.yml
@@ -1,15 +1,13 @@
-name: Deploy Alert Fix
+name: Stop Oasyce Chain
 
 on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  stop:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-
       - name: Install SSH key
         env:
           VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
@@ -18,43 +16,70 @@ jobs:
           printf '%s\n' "$VPS_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
-      - name: Deploy runtime files
+      - name: Stop and disable chain runtime
         env:
           VPS_HOST: 47.93.32.88
           VPS_PORT: 29222
           VPS_USER: root
         run: |
-          SCP_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15 -P ${VPS_PORT}"
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15 -p ${VPS_PORT}"
-
-          scp ${SCP_OPTS} deploy/healthcheck.sh "${VPS_USER}@${VPS_HOST}:/tmp/oasyce-healthcheck.sh"
-          scp ${SCP_OPTS} scripts/consumer_agent.py "${VPS_USER}@${VPS_HOST}:/tmp/oasyce-consumer_agent.py"
 
           ssh ${SSH_OPTS} "${VPS_USER}@${VPS_HOST}" 'bash -s' <<'EOF'
           set -euo pipefail
 
-          install -d -m 755 /var/lib/oasyce-healthcheck
-          install -d -m 755 /var/lib/oasyce-consumer
-          chown oasyce:oasyce /var/lib/oasyce-consumer
+          BACKUP_DIR="/var/backups/oasyce-chain-stop-$(date +%Y%m%d-%H%M%S)"
+          install -d -m 700 "${BACKUP_DIR}"
 
-          install -m 755 /tmp/oasyce-healthcheck.sh /opt/oasyce/src/deploy/healthcheck.sh
-          install -m 644 /tmp/oasyce-consumer_agent.py /opt/oasyce/src/scripts/consumer_agent.py
+          echo "=== pre-stop oasyce units ==="
+          systemctl list-units --all --no-legend | awk '$1 ~ /^oasyce/ {print}' || true
+          echo "=== pre-stop chain ports ==="
+          ss -ltnp | grep -E ':(11317|1317|8430|26656|26657)([^0-9]|$)' || true
 
-          if [ -f /tmp/consumer_agent_state.json ] && [ ! -f /var/lib/oasyce-consumer/state.json ]; then
-            cp /tmp/consumer_agent_state.json /var/lib/oasyce-consumer/state.json
-            chown oasyce:oasyce /var/lib/oasyce-consumer/state.json
+          for CRON_USER in root oasyce; do
+            if crontab -u "${CRON_USER}" -l > "${BACKUP_DIR}/${CRON_USER}.crontab" 2>/dev/null; then
+              awk '!/healthcheck\.sh|consumer_agent\.py|data_agent\.py|provider_agent\.py|\/opt\/oasyce|\/srv\/oasyce/' \
+                "${BACKUP_DIR}/${CRON_USER}.crontab" > "${BACKUP_DIR}/${CRON_USER}.filtered"
+              if [ -s "${BACKUP_DIR}/${CRON_USER}.filtered" ]; then
+                crontab -u "${CRON_USER}" "${BACKUP_DIR}/${CRON_USER}.filtered"
+              else
+                crontab -u "${CRON_USER}" -r
+              fi
+            fi
+          done
+
+          mapfile -t OASYCE_UNITS < <(
+            systemctl list-unit-files --type=service --type=timer --no-legend \
+              | awk '$1 ~ /^oasyce/ {print $1}'
+          )
+          if [ "${#OASYCE_UNITS[@]}" -gt 0 ]; then
+            systemctl disable --now "${OASYCE_UNITS[@]}"
           fi
 
-          rm -f /tmp/oasyce_health_state /tmp/oasyce_health_state.sent
-          rm -rf /tmp/oasyce_health_state_alerts
+          sleep 3
 
-          /opt/oasyce/src/scripts/healthcheck.sh
+          echo "=== post-stop oasyce units ==="
+          FAILED=0
+          for UNIT in "${OASYCE_UNITS[@]}"; do
+            ACTIVE="$(systemctl is-active "${UNIT}" 2>/dev/null || true)"
+            ENABLED="$(systemctl is-enabled "${UNIT}" 2>/dev/null || true)"
+            printf '%s active=%s enabled=%s\n' "${UNIT}" "${ACTIVE}" "${ENABLED}"
+            if [ "${ACTIVE}" = "active" ] || [ "${ENABLED}" = "enabled" ]; then
+              FAILED=1
+            fi
+          done
 
-          echo "=== healthcheck state ==="
-          find /var/lib/oasyce-healthcheck -maxdepth 2 -type f -print -exec sh -c "echo '---'; cat \"\$1\" || true" _ {} \;
-          echo "=== consumer state ==="
-          ls -la /var/lib/oasyce-consumer || true
-          cat /var/lib/oasyce-consumer/state.json || true
-          echo "=== current health ==="
-          curl -fsS http://127.0.0.1:11317/health || curl -fsS http://127.0.0.1:1317/health
+          echo "=== remaining chain cron entries ==="
+          for CRON_USER in root oasyce; do
+            crontab -u "${CRON_USER}" -l 2>/dev/null \
+              | grep -E 'healthcheck\.sh|consumer_agent\.py|data_agent\.py|provider_agent\.py|/opt/oasyce|/srv/oasyce' \
+              && FAILED=1 || true
+          done
+
+          echo "=== remaining chain ports ==="
+          if ss -ltnp | grep -E ':(11317|1317|8430|26656|26657)([^0-9]|$)'; then
+            FAILED=1
+          fi
+
+          echo "backup=${BACKUP_DIR}"
+          exit "${FAILED}"
           EOF

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # Oasyce chain healthcheck — runs via crontab every 5 min
-# Self-heals first, then alerts via email (msmtp)
+# Self-heals first and records alerts locally. Email delivery is opt-in.
 
-ALERT_EMAIL="${OASYCE_ALERT_EMAIL:-ptc0428@qq.com}"
+ALERT_EMAIL="${OASYCE_ALERT_EMAIL:-}"
+ALERT_FROM_EMAIL="${OASYCE_ALERT_FROM_EMAIL:-$ALERT_EMAIL}"
+EMAIL_ALERTS_ENABLED="${OASYCE_EMAIL_ALERTS_ENABLED:-0}"
 STATE_DIR="${OASYCE_HEALTH_STATE_DIR:-/var/lib/oasyce-healthcheck}"
 STATE_FILE="${OASYCE_HEALTH_STATE_FILE:-${STATE_DIR}/health_state}"
 ALERT_LOG="${OASYCE_ALERT_LOG:-/var/log/oasyce-alert.log}"
@@ -26,8 +28,12 @@ send_alert() {
     local ts
     ts=$(date "+%Y-%m-%d %H:%M:%S")
     echo "$ts: ALERT: $msg" >> "$ALERT_LOG"
-    printf "Subject: [Oasyce Alert] %s\nFrom: Oasyce Monitor <ptc0428@qq.com>\nTo: %s\nContent-Type: text/plain; charset=utf-8\n\n%s\n\nTime: %s\nNode: 47.93.32.88\n" \
-        "$msg" "$ALERT_EMAIL" "$msg" "$ts" | msmtp "$ALERT_EMAIL" 2>> "$ALERT_LOG"
+    if [ "$EMAIL_ALERTS_ENABLED" != "1" ] || [ -z "$ALERT_EMAIL" ]; then
+        echo "$ts: EMAIL_SKIPPED: email alerts disabled" >> "$ALERT_LOG"
+        return 0
+    fi
+    printf "Subject: [Oasyce Alert] %s\nFrom: Oasyce Monitor <%s>\nTo: %s\nContent-Type: text/plain; charset=utf-8\n\n%s\n\nTime: %s\nNode: 47.93.32.88\n" \
+        "$msg" "$ALERT_FROM_EMAIL" "$ALERT_EMAIL" "$msg" "$ts" | msmtp "$ALERT_EMAIL" 2>> "$ALERT_LOG"
 }
 
 log_alert_event() {

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -179,7 +179,8 @@ The current healthcheck is hardened to reduce live churn:
 
 - alert dedupe state is persisted under `/var/lib/oasyce-healthcheck`
 - one healthcheck instance runs at a time via a lock file
-- each alert key mails once per active incident and resets after recovery
+- each alert key records once per active incident and resets after recovery
+- email delivery is disabled by default and only activates when both `OASYCE_EMAIL_ALERTS_ENABLED=1` and `OASYCE_ALERT_EMAIL` are configured
 - consumer stale monitoring is only enabled when the consumer is actually deployed
 - provider HTTP monitoring and economy stale monitoring remain opt-in by default
 

--- a/docs/OPS_RUNBOOK.md
+++ b/docs/OPS_RUNBOOK.md
@@ -82,7 +82,8 @@ curl -s http://47.93.32.88:1317/cosmos/bank/v1beta1/balances/oasyce1msmqqjw64k8m
 - `/tmp` 清理不会再重置告警去重状态
 - healthcheck 会自动探测 consumer 是否真的部署，未部署时不再误报 `Consumer agent STALE`
 - healthcheck 有执行锁，同一时间只允许一份实例运行
-- 每个告警 key 都有冷却窗口，避免重复邮件风暴
+- 每个告警 key 都会落日志并保留去重状态
+- 邮件发送默认关闭；只有同时设置 `OASYCE_EMAIL_ALERTS_ENABLED=1` 和 `OASYCE_ALERT_EMAIL` 才会通过 `msmtp` 发信
 
 ## 本地自治验收
 

--- a/scripts/provider_agent.py
+++ b/scripts/provider_agent.py
@@ -80,7 +80,9 @@ UPSTREAM_API_KEY = os.environ.get("UPSTREAM_API_KEY", "")
 CAPABILITY_ID = os.environ.get("OASYCE_CAPABILITY_ID", "")
 PROVIDER_PORT = int(os.environ.get("PROVIDER_PORT", "8430"))
 CHAIN_ID = os.environ.get("OASYCE_CHAIN_ID") or os.environ.get("OASYCED_CHAIN_ID", "oasyce-testnet-1")
-ALERT_EMAIL = os.environ.get("OASYCE_ALERT_EMAIL", "ptc0428@qq.com")
+ALERT_EMAIL = os.environ.get("OASYCE_ALERT_EMAIL", "").strip()
+ALERT_FROM_EMAIL = os.environ.get("OASYCE_ALERT_FROM_EMAIL", ALERT_EMAIL).strip()
+EMAIL_ALERTS_ENABLED = os.environ.get("OASYCE_EMAIL_ALERTS_ENABLED", "0") == "1"
 ALERT_LOG = os.environ.get("OASYCE_ALERT_LOG", "/tmp/oasyce-provider-alert.log")
 ALERT_STATE_DIR = os.environ.get("OASYCE_ALERT_STATE_DIR", "/tmp/oasyce_provider_alerts")
 AUTO_DEACTIVATE_ON_BUY_FAILURE = os.environ.get("OASYCE_AUTO_DEACTIVATE_ON_BUY_FAILURE", "1") == "1"
@@ -228,25 +230,34 @@ def alert_state_path(key):
 
 
 def send_alert_email(msg):
+    if not EMAIL_ALERTS_ENABLED or not ALERT_EMAIL:
+        log.info("Alert email skipped because email delivery is disabled")
+        return False
+
     ts = time.strftime("%Y-%m-%d %H:%M:%S")
     subject = f"[Oasyce Alert] {msg}"
     mail = (
         f"Subject: {subject}\n"
-        f"From: Oasyce Monitor <ptc0428@qq.com>\n"
+        f"From: Oasyce Monitor <{ALERT_FROM_EMAIL}>\n"
         f"To: {ALERT_EMAIL}\n"
         "Content-Type: text/plain; charset=utf-8\n\n"
         f"{msg}\n\nTime: {ts}\n"
     )
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["msmtp", ALERT_EMAIL],
             input=mail,
             text=True,
             capture_output=True,
             check=False,
         )
+        if result.returncode != 0:
+            log.warning("msmtp failed with exit code %s", result.returncode)
+            return False
+        return True
     except FileNotFoundError:
         log.warning("msmtp not found; alert email skipped")
+        return False
 
 
 def activate_alert_once(key, msg):

--- a/tests/integration/healthcheck_script_test.go
+++ b/tests/integration/healthcheck_script_test.go
@@ -76,6 +76,39 @@ func TestDeployHealthcheckLockFileDefaultsToStateFileRoot(t *testing.T) {
 	}
 }
 
+func TestDeployHealthcheckEmailDeliveryIsOptIn(t *testing.T) {
+	tmpDir := t.TempDir()
+	alertLog := filepath.Join(tmpDir, "alert.log")
+	mailFile := filepath.Join(tmpDir, "mail.txt")
+
+	writeExecutable(t, tmpDir, "msmtp", `#!/bin/bash
+cat >> "$TEST_MAIL_FILE"
+`)
+
+	runHealthcheckCommand(
+		t,
+		[]string{
+			"PATH=" + tmpDir + ":" + os.Getenv("PATH"),
+			"TEST_MAIL_FILE=" + mailFile,
+			"OASYCE_ALERT_EMAIL=alerts@example.com",
+			"OASYCE_ALERT_LOG=" + alertLog,
+		},
+		"-lc",
+		"source "+deployHealthcheckScriptPath(t)+"; send_alert 'test alert'",
+	)
+
+	if _, err := os.Stat(mailFile); err == nil {
+		t.Fatal("email delivery should be disabled unless explicitly enabled")
+	}
+	logBody, err := os.ReadFile(alertLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logBody), "EMAIL_SKIPPED: email alerts disabled") {
+		t.Fatalf("expected disabled email delivery to be logged, got:\n%s", logBody)
+	}
+}
+
 func TestDeployHealthcheckEconomyStaleIsOptInAndDoesNotSpam(t *testing.T) {
 	tmpDir := t.TempDir()
 	stateFile := filepath.Join(tmpDir, "health_state")
@@ -127,6 +160,8 @@ esac
 		"TEST_HEIGHT_FILE=" + heightFile,
 		"OASYCE_HEALTH_STATE_FILE=" + stateFile,
 		"OASYCE_ALERT_LOG=" + alertLog,
+		"OASYCE_ALERT_EMAIL=alerts@example.com",
+		"OASYCE_EMAIL_ALERTS_ENABLED=1",
 		"OASYCE_ECON_LOG=" + econLog,
 		"OASYCE_ECON_STALE_WINDOW_HOURS=1",
 		"OASYCE_HEALTHCHECK_INTERVAL_MIN=5",
@@ -232,6 +267,8 @@ esac
 		"TEST_MODE_FILE=" + modeFile,
 		"OASYCE_HEALTH_STATE_FILE=" + stateFile,
 		"OASYCE_ALERT_LOG=" + alertLog,
+		"OASYCE_ALERT_EMAIL=alerts@example.com",
+		"OASYCE_EMAIL_ALERTS_ENABLED=1",
 		"OASYCE_ECON_LOG=" + econLog,
 	}
 
@@ -332,6 +369,8 @@ esac
 		"TEST_HEIGHT_FILE=" + heightFile,
 		"OASYCE_HEALTH_STATE_FILE=" + stateFile,
 		"OASYCE_ALERT_LOG=" + alertLog,
+		"OASYCE_ALERT_EMAIL=alerts@example.com",
+		"OASYCE_EMAIL_ALERTS_ENABLED=1",
 		"OASYCE_ECON_LOG=" + econLog,
 	}
 

--- a/tests/python/test_provider_agent.py
+++ b/tests/python/test_provider_agent.py
@@ -24,6 +24,9 @@ class ProviderAgentTests(unittest.TestCase):
         provider_agent.CAPABILITY_ID = "CAP_TEST"
         provider_agent.ALERT_LOG = str(Path(self.tempdir.name) / "alert.log")
         provider_agent.ALERT_STATE_DIR = str(Path(self.tempdir.name) / "alerts")
+        provider_agent.ALERT_EMAIL = ""
+        provider_agent.ALERT_FROM_EMAIL = ""
+        provider_agent.EMAIL_ALERTS_ENABLED = False
         provider_agent._RUNTIME = None
         provider_agent._upstream_ok = True
         provider_agent._upstream_known = False
@@ -48,6 +51,25 @@ class ProviderAgentTests(unittest.TestCase):
         self.assertEqual(payload["status"], "ok")
         self.assertIsNone(payload["upstream_ok"])
         mock_probe.assert_not_called()
+
+    def test_alert_email_is_disabled_by_default(self):
+        with mock.patch.object(provider_agent.subprocess, "run") as mock_run:
+            sent = provider_agent.send_alert_email("test alert")
+
+        self.assertFalse(sent)
+        mock_run.assert_not_called()
+
+    def test_alert_email_requires_explicit_opt_in(self):
+        provider_agent.ALERT_EMAIL = "alerts@example.com"
+        provider_agent.ALERT_FROM_EMAIL = "alerts@example.com"
+        provider_agent.EMAIL_ALERTS_ENABLED = True
+        completed = SimpleNamespace(returncode=0)
+        with mock.patch.object(provider_agent.subprocess, "run", return_value=completed) as mock_run:
+            sent = provider_agent.send_alert_email("test alert")
+
+        self.assertTrue(sent)
+        mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_args.args[0], ["msmtp", "alerts@example.com"])
 
     def test_health_probe_failure_reports_degraded_without_disabling_capability(self):
         with mock.patch.object(provider_agent, "_check_capability_cached", return_value=(True, "")), \


### PR DESCRIPTION
## Summary
- keep email delivery disabled by default and remove the private mailbox default from public source
- replace the stale runtime deployment path with an idempotent chain-stop workflow
- back up and remove chain-related root/oasyce crontab entries
- disable all `oasyce*` services and timers and verify chain ports are closed

## Production status
The shutdown workflow completed successfully on 2026-08-25. No `oasyce*` units or chain ports were active before shutdown; residual chain cron entries were filtered and backed up under `/var/backups/oasyce-chain-stop-20260825-050138`. The default-branch Deploy Alert Fix workflow is now manually disabled.

## Verification
- `go test ./tests/integration`
- `python3 -m unittest tests/python/test_provider_agent.py`
- `bash -n deploy/healthcheck.sh scripts/healthcheck.sh`
- shutdown run: https://github.com/Shangri-la-0428/oasyce-chain/actions/runs/32777198797